### PR TITLE
Add configurable deployment and queue

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,8 @@
 ADMIN_KEY=your_secure_api_key_here
 WHISPER_MODEL=openai/whisper-small
 MAX_FILE_SIZE=52428800  # 50MB in bytes
+CORS_ORIGINS=*
+CORS_METHODS=*
+CORS_HEADERS=*
+USE_REDIS_QUEUE=0
+REDIS_URL=redis://redis:6379/0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.10-slim
 
+ARG WHISPER_MODEL=openai/whisper-small
+ARG ADMIN_KEY=default-admin-key-change-me
+
 # Set working directory
 WORKDIR /app
 
@@ -40,8 +43,9 @@ EXPOSE 5000
 ENV PYTHONPATH="/app"
 ENV PYTHONUNBUFFERED="1"
 
-# Set a default admin key (should be overridden in docker-compose)
-ENV ADMIN_KEY="default-admin-key-change-me"
+# Set variables that can be overridden at runtime
+ENV ADMIN_KEY=${ADMIN_KEY}
+ENV WHISPER_MODEL=${WHISPER_MODEL}
 
 # Create a non-root user and switch to it
 RUN useradd -m appuser && \

--- a/README.md
+++ b/README.md
@@ -24,30 +24,35 @@ An API to transcribe audio with OpenAI's Whisper Large v3! Powered by 🤗 Trans
    cd insanely-fast-whisper-api
    ```
 
-2. Install dependencies:
+2. Install dependencies (optional when using Docker):
    ```bash
    pip install -r requirements.txt
    ```
 
 ## Configuration
 
-Create a `.env` file in the project root with the following variables:
+Copy `.env.example` to `.env` and adjust the values for your environment:
 
 ```env
 ADMIN_KEY=your_secure_admin_key_here
+WHISPER_MODEL=openai/whisper-small
+MAX_FILE_SIZE=52428800
 CORS_ORIGINS=*
 CORS_METHODS=*
 CORS_HEADERS=*
+USE_REDIS_QUEUE=0
+REDIS_URL=redis://redis:6379/0
 ```
 
 ## Running with Docker
 
-1. Build and start the container:
+1. Build and start the containers:
    ```bash
    docker-compose up --build
    ```
 
 2. The API will be available at `http://localhost:5000`
+3. When `USE_REDIS_QUEUE=1` a worker and Redis container will handle queued jobs.
 
 ## API Endpoints
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,12 +8,37 @@ services:
     env_file:
       - .env
     environment:
-      - CORS_ORIGINS=*
-      - CORS_METHODS=*
-      - CORS_HEADERS=*
+      - CORS_ORIGINS=${CORS_ORIGINS}
+      - CORS_METHODS=${CORS_METHODS}
+      - CORS_HEADERS=${CORS_HEADERS}
       - PYTHONUNBUFFERED=1
-      - ADMIN_KEY=hofP20MHXVh5ZhI30QXHA_ly_zqG__ktnQtQpwmXnoo  # API-sleutel voor authenticatie
+      - ADMIN_KEY=${ADMIN_KEY}
+      - WHISPER_MODEL=${WHISPER_MODEL}
+      - USE_REDIS_QUEUE=${USE_REDIS_QUEUE}
+      - REDIS_URL=${REDIS_URL}
     volumes:
       - .:/app
+      - ./data:/tmp/whisper_uploads
     working_dir: /app
+    restart: unless-stopped
+
+  worker:
+    build: .
+    command: ["python", "-m", "insanely_fast_whisper_api.app.worker"]
+    env_file:
+      - .env
+    environment:
+      - PYTHONUNBUFFERED=1
+      - ADMIN_KEY=${ADMIN_KEY}
+      - WHISPER_MODEL=${WHISPER_MODEL}
+      - REDIS_URL=${REDIS_URL}
+    volumes:
+      - .:/app
+      - ./data:/tmp/whisper_uploads
+    working_dir: /app
+    depends_on:
+      - redis
+
+  redis:
+    image: redis:7
     restart: unless-stopped

--- a/src/insanely_fast_whisper_api/app/app.py
+++ b/src/insanely_fast_whisper_api/app/app.py
@@ -1,10 +1,21 @@
-from fastapi import FastAPI, HTTPException, UploadFile, File, Header, Request, BackgroundTasks, APIRouter, status, Form
+from fastapi import (
+    FastAPI,
+    HTTPException,
+    UploadFile,
+    File,
+    Header,
+    Request,
+    BackgroundTasks,
+    APIRouter,
+    status,
+    Form,
+)
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse, FileResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel, BaseSettings
-from typing import Optional, Dict, List, Tuple
+from typing import Optional, Dict
 import torch
 from transformers import pipeline
 import os
@@ -19,39 +30,57 @@ import logging
 import subprocess
 import shutil
 import json
+import redis
+from dotenv import load_dotenv
+
+load_dotenv()
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+
 # Admin settings
 class Settings(BaseSettings):
     admin_webhook_url: str = ""
-    admin_api_key: str = os.getenv("ADMIN_KEY", "test123")  # Default waarde voor testen
-    
+    admin_api_key: str = "test123"
+    whisper_model: str = "openai/whisper-small"
+    cors_origins: str = "*"
+    cors_methods: str = "*"
+    cors_headers: str = "*"
+    max_file_size: int = 50 * 1024 * 1024
+    use_redis_queue: bool = False
+    redis_url: str = "redis://redis:6379/0"
+
     class Config:
         env_file = ".env"
-        env_file_encoding = 'utf-8'
+        env_file_encoding = "utf-8"
         case_sensitive = False
 
+
 settings = Settings()
-logger.info(f"API Key loaded: {'*' * len(settings.admin_api_key) if settings.admin_api_key else 'None'}")
+logger.info(
+    f"API Key loaded: {'*' * len(settings.admin_api_key) if settings.admin_api_key else 'None'}"
+)
+
+# Optional Redis client for queueing
+redis_client = redis.from_url(settings.redis_url) if settings.use_redis_queue else None
 
 # Supported audio formats
 SUPPORTED_AUDIO_TYPES = [
-    'audio/wav',
-    'audio/mpeg',
-    'audio/mp3',
-    'audio/x-wav',
-    'audio/x-m4a',
-    'audio/mp4',
-    'audio/aac',
-    'audio/ogg',
-    'audio/webm'
+    "audio/wav",
+    "audio/mpeg",
+    "audio/mp3",
+    "audio/x-wav",
+    "audio/x-m4a",
+    "audio/mp4",
+    "audio/aac",
+    "audio/ogg",
+    "audio/webm",
 ]
 
-# Maximum file size (50MB)
-MAX_FILE_SIZE = 50 * 1024 * 1024
+# Maximum file size
+MAX_FILE_SIZE = settings.max_file_size
 
 # Create main FastAPI app
 app = FastAPI(title="Insanely Fast Whisper API")
@@ -62,13 +91,14 @@ api_router = APIRouter(prefix="/api")
 # CORS middleware
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=os.getenv("CORS_ORIGINS", "*").split(","),
+    allow_origins=settings.cors_origins.split(","),
     allow_credentials=True,
-    allow_methods=os.getenv("CORS_METHODS", "*").split(","),
-    allow_headers=os.getenv("CORS_HEADERS", "*").split(","),
+    allow_methods=settings.cors_methods.split(","),
+    allow_headers=settings.cors_headers.split(","),
     expose_headers=["Content-Type", "Authorization", "X-Requested-With"],
-    max_age=3600
+    max_age=3600,
 )
+
 
 # Models
 class TranscriptionRequest(BaseModel):
@@ -82,14 +112,17 @@ class TranscriptionRequest(BaseModel):
     is_async: bool = False
     managed_task_id: Optional[str] = None
 
+
 class TranscriptionResponse(BaseModel):
     text: str
     task_id: str
     status: str
     created_at: datetime
 
+
 # Initialize Whisper pipeline
 whisper_pipeline = None
+
 
 def get_whisper_pipeline():
     global whisper_pipeline
@@ -97,14 +130,14 @@ def get_whisper_pipeline():
         logger.info("Initializing Whisper pipeline...")
         device = 0 if torch.cuda.is_available() else -1
         torch_dtype = torch.float16 if torch.cuda.is_available() else torch.float32
-        
+
         logger.info(f"Using device: {'CUDA' if device >= 0 else 'CPU'}")
         logger.info(f"Using torch_dtype: {torch_dtype}")
-        
-        # Use a larger model for better accuracy
-        model_name = "openai/whisper-small"
+
+        # Load model from environment
+        model_name = settings.whisper_model
         logger.info(f"Loading model: {model_name}")
-        
+
         try:
             whisper_pipeline = pipeline(
                 "automatic-speech-recognition",
@@ -112,57 +145,61 @@ def get_whisper_pipeline():
                 device=device,
                 torch_dtype=torch_dtype,
                 chunk_length_s=30,  # Process in 30-second chunks
-                stride_length_s=5,   # Overlap chunks by 5 seconds
-                return_timestamps=False
+                stride_length_s=5,  # Overlap chunks by 5 seconds
+                return_timestamps=False,
             )
             logger.info("Whisper pipeline initialized successfully")
         except Exception as e:
             logger.error(f"Failed to initialize Whisper pipeline: {str(e)}")
             raise
-            
+
     return whisper_pipeline
+
 
 # Utility functions
 async def download_audio(url: str) -> str:
     """Download audio from URL and return local file path."""
     temp_dir = Path(tempfile.gettempdir())
     temp_file = temp_dir / f"audio_{uuid.uuid4()}.wav"
-    
+
     async with aiohttp.ClientSession() as session:
         async with session.get(url) as response:
             if response.status != 200:
-                raise HTTPException(status_code=400, detail="Failed to download audio file")
-            
+                raise HTTPException(
+                    status_code=400, detail="Failed to download audio file"
+                )
+
             with open(temp_file, "wb") as f:
                 while True:
                     chunk = await response.content.read(1024)
                     if not chunk:
                         break
                     f.write(chunk)
-    
+
     return str(temp_file)
+
 
 def convert_audio(input_path: str, output_path: str = None) -> str:
     """Convert audio file to WAV format using FFmpeg."""
     if output_path is None:
-        output_path = str(Path(input_path).with_suffix('.wav'))
-    
+        output_path = str(Path(input_path).with_suffix(".wav"))
+
     try:
         # Convert to WAV with 16kHz sample rate and mono channel
         cmd = [
-            'ffmpeg',
-            '-i', input_path,    # Input file
-            '-ar', '16000',     # Audio sample rate
-            '-ac', '1',         # Mono audio
-            '-y',               # Overwrite output file if it exists
-            output_path
+            "ffmpeg",
+            "-i",
+            input_path,  # Input file
+            "-ar",
+            "16000",  # Audio sample rate
+            "-ac",
+            "1",  # Mono audio
+            "-y",  # Overwrite output file if it exists
+            output_path,
         ]
-        
+
         result = subprocess.run(
-            cmd,
-            check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE
+            cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
         logger.info(f"Audio converted successfully: {output_path}")
         return output_path
@@ -170,8 +207,9 @@ def convert_audio(input_path: str, output_path: str = None) -> str:
         logger.error(f"FFmpeg conversion failed: {e.stderr.decode()}")
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail="Kon het audiobestand niet converteren naar een bruikbaar formaat"
+            detail="Kon het audiobestand niet converteren naar een bruikbaar formaat",
         )
+
 
 async def validate_uploaded_file(file: UploadFile) -> dict:
     """Validate the uploaded file and return file info."""
@@ -179,47 +217,48 @@ async def validate_uploaded_file(file: UploadFile) -> dict:
     file.file.seek(0, 2)  # Move to end of file
     file_size = file.file.tell()
     file.file.seek(0)  # Reset file pointer
-    
+
     if file_size > MAX_FILE_SIZE:
         raise HTTPException(
             status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
-            detail=f"Bestand is te groot. Maximale grootte is {MAX_FILE_SIZE/1024/1024}MB"
+            detail=f"Bestand is te groot. Maximale grootte is {MAX_FILE_SIZE/1024/1024}MB",
         )
-    
+
     # Get file extension
     file_extension = Path(file.filename).suffix.lower()
-    
+
     # Check if FFmpeg is available
-    ffmpeg_available = shutil.which('ffmpeg') is not None
-    
+    ffmpeg_available = shutil.which("ffmpeg") is not None
+
     # If FFmpeg is not available, only allow WAV files
-    if not ffmpeg_available and file_extension != '.wav':
+    if not ffmpeg_available and file_extension != ".wav":
         raise HTTPException(
             status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
-            detail="Alleen WAV-bestanden worden ondersteund. Installeer FFmpeg voor ondersteuning van meer formaten."
+            detail="Alleen WAV-bestanden worden ondersteund. Installeer FFmpeg voor ondersteuning van meer formaten.",
         )
-    
+
     # Check file type
     content_type = file.content_type
     if not content_type:
         # Try to guess content type from filename
         content_type = mimetypes.guess_type(file.filename)[0]
-    
+
     # If we couldn't determine content type, try to proceed anyway if FFmpeg is available
     if not content_type and not ffmpeg_available:
         raise HTTPException(
             status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
-            detail="Kon het bestandstype niet bepalen"
+            detail="Kon het bestandstype niet bepalen",
         )
-    
+
     # Check if the file needs conversion
-    needs_conversion = file_extension not in ['.wav', '.mp3']
-    
+    needs_conversion = file_extension not in [".wav", ".mp3"]
+
     return {
-        'needs_conversion': needs_conversion,
-        'extension': file_extension,
-        'content_type': content_type
+        "needs_conversion": needs_conversion,
+        "extension": file_extension,
+        "content_type": content_type,
     }
+
 
 # API Endpoints
 @api_router.post("/transcribe")
@@ -227,60 +266,76 @@ async def transcribe_audio(
     background_tasks: BackgroundTasks,
     file: Optional[UploadFile] = File(None),
     request: Request = None,
-    x_admin_api_key: str = Header(None)
+    x_admin_api_key: str = Header(None),
 ):
     # Validate API key
-    if x_admin_api_key != os.getenv("ADMIN_KEY"):
+    if x_admin_api_key != settings.admin_api_key:
         raise HTTPException(status_code=401, detail="Invalid API key")
-    
+
     # Check if either file or URL is provided
     if file is None:
         raise HTTPException(status_code=400, detail="No file provided")
-    
+
     # Generate task ID
     task_id = str(uuid.uuid4())
-    
+
     try:
         # Create temp directory if it doesn't exist
         temp_dir = Path(tempfile.gettempdir()) / "whisper_uploads"
         temp_dir.mkdir(exist_ok=True, parents=True)
-        
+
         # Save uploaded file
         temp_file = temp_dir / f"audio_{task_id}_{file.filename}"
-        output_file = temp_file.with_suffix('.wav')
-        
+        output_file = temp_file.with_suffix(".wav")
+
         try:
             # Save uploaded file
             with open(temp_file, "wb") as buffer:
                 content = await file.read()
                 buffer.write(content)
-            
+
             logger.info(f"File saved to {temp_file}")
-            
-            # Get the language from the form data
+
+            # Get the language and async flag from the form data
             form_data = await request.form()
-            language = form_data.get('language', 'nl')  # Default to Dutch if not provided
+            language = form_data.get(
+                "language", "nl"
+            )  # Default to Dutch if not provided
+            is_async_flag = form_data.get("is_async", "false").lower() == "true"
             logger.info(f"Language: {language}")
-            
+
             # Validate file and check if conversion is needed
             file_info = await validate_uploaded_file(file)
-            
+
             # Convert audio if needed
-            if file_info['needs_conversion']:
+            if file_info["needs_conversion"]:
                 logger.info(f"Converting {temp_file} to WAV format...")
                 convert_audio(str(temp_file), str(output_file))
                 # Remove original file after conversion
                 temp_file.unlink()
             else:
                 output_file = temp_file
-            
+
+            # Queue the task if async processing is requested
+            if (settings.use_redis_queue or is_async_flag) and redis_client:
+                task_payload = {
+                    "task_id": task_id,
+                    "file_path": str(output_file),
+                    "language": language,
+                }
+                redis_client.rpush("transcription_tasks", json.dumps(task_payload))
+                logger.info(f"Task {task_id} queued")
+                return {"task_id": task_id, "status": "queued"}
+
             # Get the transcription pipeline
             pipeline = get_whisper_pipeline()
-                
+
             try:
                 # Log the language being used
-                logger.info(f"Starting transcription of {output_file} (language: {language or 'auto'})...")
-                
+                logger.info(
+                    f"Starting transcription of {output_file} (language: {language or 'auto'})..."
+                )
+
                 try:
                     # Prepare generation kwargs
                     generate_kwargs = {
@@ -288,57 +343,55 @@ async def transcribe_audio(
                         "return_timestamps": True,
                         "chunk_length_s": 30,
                         "batch_size": 16,
-                        "language": language if language and language != "auto" else None,
+                        "language": (
+                            language if language and language != "auto" else None
+                        ),
                     }
-                    
+
                     # Run transcription
                     logger.info("Starting transcription...")
-                    result = pipeline(
-                        str(output_file),
-                        **generate_kwargs
-                    )
-                    
+                    result = pipeline(str(output_file), **generate_kwargs)
+
                     # Format the result
                     segments = []
                     for segment in result["chunks"]:
-                        segments.append({
-                            "start": segment["timestamp"][0],
-                            "end": segment["timestamp"][1],
-                            "text": segment["text"].strip()
-                        })
-                    
+                        segments.append(
+                            {
+                                "start": segment["timestamp"][0],
+                                "end": segment["timestamp"][1],
+                                "text": segment["text"].strip(),
+                            }
+                        )
+
                     # Clean up the output file
                     output_file.unlink()
-                    
+
                     return {
                         "task_id": task_id,
                         "status": "completed",
                         "text": result["text"],
                         "segments": segments,
-                        "language": language or "auto"
+                        "language": language or "auto",
                     }
-                    
+
                 except Exception as e:
                     logger.error(f"Error during transcription: {str(e)}")
                     raise HTTPException(
-                        status_code=500,
-                        detail=f"Error during transcription: {str(e)}"
+                        status_code=500, detail=f"Error during transcription: {str(e)}"
                     )
-                    
+
             except Exception as e:
                 logger.error(f"Error processing file: {str(e)}")
                 raise HTTPException(
-                    status_code=500,
-                    detail=f"Error processing file: {str(e)}"
+                    status_code=500, detail=f"Error processing file: {str(e)}"
                 )
-                
+
         except Exception as e:
             logger.error(f"Unexpected error: {str(e)}")
             raise HTTPException(
-                status_code=500,
-                detail=f"An unexpected error occurred: {str(e)}"
+                status_code=500, detail=f"An unexpected error occurred: {str(e)}"
             )
-            
+
         finally:
             # Clean up
             try:
@@ -346,30 +399,31 @@ async def transcribe_audio(
                     temp_file.unlink()
             except Exception as e:
                 logger.warning(f"Failed to delete temp file {temp_file}: {e}")
-            
+
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
+
 
 async def process_sync_transcription(request: TranscriptionRequest, task_id: str):
     """Process transcription synchronously."""
     try:
         # Download audio
         audio_path = await download_audio(request.url)
-        
+
         # Get the transcription pipeline
         pipeline = get_whisper_pipeline()
-        
+
         # Transcribe audio
         result = pipeline(
             audio_path,
             language=request.language,
             batch_size=request.batch_size,
-            return_timestamps=request.timestamp != "none"
+            return_timestamps=request.timestamp != "none",
         )
-        
+
         # Clean up
         Path(audio_path).unlink()
-        
+
         return TranscriptionResponse(
             text=result["text"],
             task_id=task_id,
@@ -378,6 +432,7 @@ async def process_sync_transcription(request: TranscriptionRequest, task_id: str
         )
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
+
 
 async def process_async_transcription(request: TranscriptionRequest, task_id: str):
     """Process transcription asynchronously."""
@@ -389,50 +444,63 @@ async def process_async_transcription(request: TranscriptionRequest, task_id: st
         # Log the error
         print(f"Error in async transcription: {e}")
 
+
 @api_router.get("/api/config")
 async def get_config():
     """Get frontend configuration (including API key if needed)."""
     return {
         "apiKeyRequired": True,
-        "maxFileSize": 50 * 1024 * 1024  # 50MB
+        "maxFileSize": MAX_FILE_SIZE,
     }
+
 
 @api_router.get("/health")
 async def health_check():
     """Health check endpoint."""
     return {"status": "ok", "timestamp": datetime.utcnow()}
 
+
 @api_router.get("/tasks")
 async def get_tasks():
     # Implement task management
     return []
 
+
 @api_router.get("/status/{task_id}")
 async def get_task_status(task_id: str):
-    # Implement task status retrieval
-    return {"status": "completed"}
+    if not redis_client:
+        raise HTTPException(status_code=400, detail="Queueing not enabled")
+    data = redis_client.get(f"result:{task_id}")
+    if not data:
+        return {"status": "pending"}
+    return json.loads(data)
+
 
 @api_router.delete("/tasks/{task_id}")
 async def cancel_task(task_id: str):
     # Implement task cancellation
     return {"status": "cancelled"}
 
+
 # Middleware voor API key validatie
 @app.middleware("http")
 async def validate_api_key(request: Request, call_next):
     # Skip API key check for health check and static files
-    if request.url.path in ['/health', '/api/config'] or request.url.path.startswith('/static/'):
+    if request.url.path in ["/health", "/api/config"] or request.url.path.startswith(
+        "/static/"
+    ):
         return await call_next(request)
-        
+
     # Check for API key in headers
-    api_key = request.headers.get('x-admin-api-key')
+    api_key = request.headers.get("x-admin-api-key")
     if not api_key or api_key != settings.admin_api_key:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Ongeldige of ontbrekende API key"
+            detail="Ongeldige of ontbrekende API key",
         )
-    
+
     return await call_next(request)
+
 
 # Create FastAPI app
 app = FastAPI(title="Insanely Fast Whisper API")
@@ -440,11 +508,11 @@ app = FastAPI(title="Insanely Fast Whisper API")
 # Configure CORS
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:8000", "http://127.0.0.1:8000"],
+    allow_origins=settings.cors_origins.split(","),
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-    expose_headers=["*"]
+    allow_methods=settings.cors_methods.split(","),
+    allow_headers=settings.cors_headers.split(","),
+    expose_headers=["*"],
 )
 
 # Mount static files
@@ -458,6 +526,7 @@ except Exception as e:
     # Create a minimal template
     templates = None
 
+
 # API endpoints
 @app.get("/api/config")
 async def get_config():
@@ -465,74 +534,85 @@ async def get_config():
     return {
         "apiKeyRequired": bool(settings.admin_api_key),
         "maxFileSize": MAX_FILE_SIZE,
-        "supportedAudioTypes": SUPPORTED_AUDIO_TYPES
+        "supportedAudioTypes": SUPPORTED_AUDIO_TYPES,
     }
+
 
 # Admin routes
 @app.get("/admin", response_class=HTMLResponse)
 async def admin_ui(request: Request):
-    return templates.TemplateResponse("admin.html", {
-        "request": request, 
-        "webhook_url": settings.admin_webhook_url,
-        "admin_api_key": settings.admin_api_key
-    })
+    return templates.TemplateResponse(
+        "admin.html",
+        {
+            "request": request,
+            "webhook_url": settings.admin_webhook_url,
+            "admin_api_key": settings.admin_api_key,
+        },
+    )
+
 
 @app.post("/admin/save")
-async def save_settings(webhook_url: str = Form(...), x_admin_api_key: str = Header(None)):
+async def save_settings(
+    webhook_url: str = Form(...), x_admin_api_key: str = Header(None)
+):
     if x_admin_api_key != settings.admin_api_key:
         raise HTTPException(status_code=401, detail="Invalid API key")
-    
+
     settings.admin_webhook_url = webhook_url
     # Save to .env file or another persistent storage
     with open(".env", "w") as f:
         f.write(f"ADMIN_WEBHOOK_URL={webhook_url}\n")
-    
+
     return {"status": "success", "message": "Settings saved successfully"}
+
 
 # Webhook endpoint for n8n
 @api_router.post("/webhook/transcribe")
-async def webhook_transcribe(file: UploadFile = File(...), x_admin_api_key: str = Header(None)):
+async def webhook_transcribe(
+    file: UploadFile = File(...), x_admin_api_key: str = Header(None)
+):
     if x_admin_api_key != settings.admin_api_key:
         raise HTTPException(status_code=401, detail="Invalid API key")
-    
+
     # Process the file using existing transcribe function
     task_id = str(uuid.uuid4())
     temp_dir = Path(tempfile.gettempdir()) / "whisper_uploads"
     temp_dir.mkdir(exist_ok=True, parents=True)
-    
+
     temp_file = temp_dir / f"webhook_audio_{task_id}_{file.filename}"
-    output_file = temp_file.with_suffix('.wav')
-    
+    output_file = temp_file.with_suffix(".wav")
+
     try:
         with open(temp_file, "wb") as buffer:
             content = await file.read()
             buffer.write(content)
-        
+
         # Convert if needed
-        if temp_file.suffix.lower() != '.wav':
+        if temp_file.suffix.lower() != ".wav":
             output_file = convert_audio(str(temp_file), str(output_file))
             temp_file.unlink()
         else:
             output_file = temp_file
-        
+
         # Transcribe
         pipeline = get_whisper_pipeline()
         result = pipeline(
             str(output_file),
             batch_size=16,
             return_timestamps=False,
-            generate_kwargs={"language": "nl"}
+            generate_kwargs={"language": "nl"},
         )
-        
+
         # Cleanup
         if output_file.exists():
             output_file.unlink()
-        
+
         return {"transcript": result["text"], "status": "completed"}
-        
+
     except Exception as e:
         logger.error(f"Webhook transcription error: {str(e)}")
         raise HTTPException(status_code=500, detail=str(e))
+
 
 # Include the API router
 app.include_router(api_router)

--- a/src/insanely_fast_whisper_api/app/worker.py
+++ b/src/insanely_fast_whisper_api/app/worker.py
@@ -1,0 +1,63 @@
+import json
+import logging
+from pathlib import Path
+import redis
+
+from dotenv import load_dotenv
+from pydantic import BaseSettings
+
+from .app import get_whisper_pipeline
+
+load_dotenv()
+
+
+class Settings(BaseSettings):
+    redis_url: str = "redis://redis:6379/0"
+
+    class Config:
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+
+
+settings = Settings()
+redis_client = redis.from_url(settings.redis_url)
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def main():
+    pipeline = get_whisper_pipeline()
+    logger.info("Worker started, waiting for tasks")
+    while True:
+        job = redis_client.blpop("transcription_tasks")
+        if not job:
+            continue
+        _, data = job
+        task = json.loads(data)
+        task_id = task["task_id"]
+        file_path = task["file_path"]
+        language = task.get("language", "nl")
+        logger.info(f"Processing task {task_id}")
+        try:
+            result = pipeline(
+                file_path,
+                batch_size=16,
+                return_timestamps=False,
+                generate_kwargs={"language": language},
+            )
+            redis_client.set(
+                f"result:{task_id}",
+                json.dumps({"text": result["text"], "status": "completed"}),
+            )
+        except Exception as e:
+            logger.error(f"Error processing task {task_id}: {e}")
+            redis_client.set(
+                f"result:{task_id}", json.dumps({"status": "error", "detail": str(e)})
+            )
+        finally:
+            Path(file_path).unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- load environment from `.env`
- add queue support using Redis
- allow customizing model and CORS from env
- template Dockerfile and docker-compose
- document configuration and quick start

## Testing
- `python -m py_compile src/insanely_fast_whisper_api/app/app.py src/insanely_fast_whisper_api/app/worker.py`

------
https://chatgpt.com/codex/tasks/task_e_685ef912f06c83229562500056c450fd